### PR TITLE
change url to main repo

### DIFF
--- a/Resources/plugin_details.json
+++ b/Resources/plugin_details.json
@@ -1657,7 +1657,7 @@
         "bundle"          :     "Lazyman.bundle",
         "type"            :     ["Video"],
         "description"     :     "Watch MLB and NHL games, recaps, and highlights",
-        "repo"            :     "https://github.com/unclenoriega/Lazyman.bundle",
+        "repo"            :     "https://github.com/nomego/Lazyman.bundle",
         "branch"          :     "master",
         "DeleteCacheDir"  :     false,
         "DeleteDataDir"   :     false,


### PR DESCRIPTION
The original author of the plugin has merged MLB support, so I would like to update the link to point to the original repo.