### PR TITLE
New Adult DVD Empire Metadata Agent

### DIFF
--- a/Resources/plugin_details.json
+++ b/Resources/plugin_details.json
@@ -17,13 +17,13 @@
         "bundle"          :     "AdultDVDEmpire.bundle",
         "type"            :     ["Metadata Agent", "Adult"],
         "description"     :     "Metadata agent for adult movies",
-        "repo"            :     "https://github.com/jesperrasmussen/AdultDVDEmpire.bundle",
+        "repo"            :     "https://github.com/naguar/AdultDVDEmpire.bundle",
         "branch"          :     "master",
         "DeleteCacheDir"  :     false,
         "DeleteDataDir"   :     false,
         "identifier"      :     "com.plexapp.agents.adultdvdempire",
         "icon"            :     "icon-adultdvdempire.png",
-        "supporturl"      :     "https://forums.plex.tv/discussion/260610"
+        "supporturl"      :     "https://forums.plex.tv/t/rel-adult-dvd-empire-metadata-agent-2018/277371"
     },
     {
         "title"           :     "AniDB.net Metadata Agent",


### PR DESCRIPTION
Change to new version URL. Old agent has not been updated for very long and missed a lot of content due to source page changes and agent often failed with error which made scrape function unstable and metadata got update to 50% complete per title. Also added functionality, cast photos, director and genres.